### PR TITLE
fix: visualization issue with odd shapes

### DIFF
--- a/cpp/src/sam3/sam3_trt/prepost.cu
+++ b/cpp/src/sam3/sam3_trt/prepost.cu
@@ -148,7 +148,11 @@ __global__ void draw_instance_seg_mask(
             for (int iy=0; iy < THREAD_COARSENING_FACTOR; iy++)
             {
                 int res_loc_x = resX*THREAD_COARSENING_FACTOR + ix;
+                res_loc_x = min(res_loc_x, src_width-1);
+
                 int res_loc_y = resY*THREAD_COARSENING_FACTOR + iy;
+                res_loc_y = min(res_loc_y, src_height-1);
+                
                 int res_loc = (res_loc_y*src_width + res_loc_x)*src_channels;
 
                 int mask_loc_x = res_loc_x*mask_width/src_width;

--- a/cpp/src/sam3/sam3_trt/prepost.cu
+++ b/cpp/src/sam3/sam3_trt/prepost.cu
@@ -92,7 +92,11 @@ __global__ void draw_semantic_seg_mask(
             for (int iy=0; iy < THREAD_COARSENING_FACTOR; iy++)
             {
                 int res_loc_x = resX*THREAD_COARSENING_FACTOR + ix;
+                res_loc_x = min(res_loc_x, src_width-1);
+
                 int res_loc_y = resY*THREAD_COARSENING_FACTOR + iy;
+                res_loc_y = min(res_loc_y, src_height-1);
+
                 int res_loc = (res_loc_y*src_width + res_loc_x)*src_channels;
 
                 int mask_loc_x = res_loc_x*mask_width/src_width;


### PR DESCRIPTION
# Issue
This PR fixes issue #8 
There was a lack of bounds check in the indices which caused issues when
```Shell
 image.width%THREAD_COARSENINGFACTOR !=0 # or
 image.height%THREAD_COARSENINGFACTOR !=0
```

# Test
Image size: 1267x845
![dog_test_oddshapes](https://github.com/user-attachments/assets/91639d81-c4ec-46fd-9dc6-20e6f3886b1f)

Semantic segmentation result
![res_dog_test_oddshapes_semantic](https://github.com/user-attachments/assets/dae0f9c1-83a0-4b8b-ab3d-9d63411806bb)

Instance segmentation result
![res_dog_test_oddshapes_instance](https://github.com/user-attachments/assets/33d037d3-39b0-478f-8f6e-a21c776c03a4)
